### PR TITLE
Upgrade to Debian 11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11.0
+FROM debian:11.2
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Mise à jour de Debian. L'image reconstruite a également mis à jour les paquets utilisés.